### PR TITLE
Rehookup the ProcessCell Logic & Move the Deque stuff into the SpreadSheetDequeManager & some cleanup a splitting

### DIFF
--- a/OpenXMLXLXSImporter/CellData/CellDataRelation.cs
+++ b/OpenXMLXLXSImporter/CellData/CellDataRelation.cs
@@ -15,11 +15,10 @@ namespace OpenXMLXLSXImporter.CellData
     {
         private string _content;
         private OpenXmlElement _sharedStringResult;
-        public CellDataRelation(int index, SharedStringTable sst)
+        public CellDataRelation(int index,OpenXmlElement sharedStringResult)
         {
             _content = null;
             Index = index;
-            _sharedStringResult = sst.ElementAt(index);
             _content = _sharedStringResult.FirstChild.InnerText;
         }
 

--- a/OpenXMLXLXSImporter/CellData/CellDataRelation.cs
+++ b/OpenXMLXLXSImporter/CellData/CellDataRelation.cs
@@ -19,6 +19,7 @@ namespace OpenXMLXLSXImporter.CellData
         {
             _content = null;
             Index = index;
+            _sharedStringResult = sharedStringResult;
             _content = _sharedStringResult.FirstChild.InnerText;
         }
 

--- a/OpenXMLXLXSImporter/ExcelImporter.cs
+++ b/OpenXMLXLXSImporter/ExcelImporter.cs
@@ -26,6 +26,7 @@ namespace OpenXMLXLSXImporter
     public class ExcelImporter : IExcelImporter
     {
         private XlsxDocumentFile _streamSheetFile;
+        private SpreadSheetDequeManager dequeManager;
         public static IExcelImporter CreateExcelImporter(Stream stream) => new ExcelImporter(stream);
         public ExcelImporter(Stream stream)
         {
@@ -42,7 +43,7 @@ namespace OpenXMLXLSXImporter
                     Task<IXlsxSheetFilePromise> gt = _streamSheetFile.LoadSpreadSheetData(sheet);
                     sheet.LoadConfig(ssib);
                     IXlsxSheetFilePromise g = await gt;
-                    SpreadSheetDequeManager dequeManager = new SpreadSheetDequeManager();
+                    dequeManager = new SpreadSheetDequeManager();
                     SpreadSheetInstructionManager ssim = new SpreadSheetInstructionManager(dequeManager);
                     dequeManager.StartRequestProcessor(g);
                     await ssib.ProcessInstructions(ssim);
@@ -61,7 +62,7 @@ namespace OpenXMLXLSXImporter
 
         public void Dispose()
         {
-            
+            dequeManager?.Finish();//we have all of our results processed we are finished adding
         }
     }
 }

--- a/OpenXMLXLXSImporter/ExcelImporter.cs
+++ b/OpenXMLXLXSImporter/ExcelImporter.cs
@@ -39,10 +39,13 @@ namespace OpenXMLXLSXImporter
                 try
                 {
                     SpreadSheetInstructionBuilder ssib = new SpreadSheetInstructionBuilder();
-                    Task<SpreadSheetInstructionManager> gt = _streamSheetFile.LoadSpreadSheetData(sheet);
+                    Task<IXlsxSheetFilePromise> gt = _streamSheetFile.LoadSpreadSheetData(sheet);
                     sheet.LoadConfig(ssib);
-                    SpreadSheetInstructionManager g = await gt;
-                    await ssib.ProcessInstructions(g);
+                    IXlsxSheetFilePromise g = await gt;
+                    SpreadSheetDequeManager dequeManager = new SpreadSheetDequeManager();
+                    SpreadSheetInstructionManager ssim = new SpreadSheetInstructionManager(dequeManager);
+                    dequeManager.StartRequestProcessor(g);
+                    await ssib.ProcessInstructions(ssim);
                     Task r = ssib.ProcessResults();
                     await sheet.ResultsProcessed(ssib);
                     await r;

--- a/OpenXMLXLXSImporter/FileAccess/IXlsxDocumentFile.cs
+++ b/OpenXMLXLXSImporter/FileAccess/IXlsxDocumentFile.cs
@@ -1,4 +1,5 @@
-﻿using DocumentFormat.OpenXml.Packaging;
+﻿using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using System;
 using System.Collections.Generic;
@@ -12,5 +13,9 @@ namespace OpenXMLXLSXImporter.FileAccess
     {
         Sheet GetSheet(string sheetName);
         WorkbookPart WorkbookPart { get; }
+
+        CellFormat GetCellFormat(int index);
+
+        OpenXmlElement GetSharedStringTableElement(int index);
     }
 }

--- a/OpenXMLXLXSImporter/FileAccess/IXlsxSheetFile.cs
+++ b/OpenXMLXLXSImporter/FileAccess/IXlsxSheetFile.cs
@@ -1,0 +1,16 @@
+﻿using DocumentFormat.OpenXml.Spreadsheet;
+using OpenXMLXLSXImporter.CellData;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OpenXMLXLSXImporter.FileAccess
+{
+    public interface IXlsxSheetFile
+    {
+        bool TryGetRow(uint desiredRowIndex, out IEnumerator<Cell> cellEnumerator);
+        void ProcessedCell(Cell cellElement, ICellProcessingTask cellPromise);
+    }
+}

--- a/OpenXMLXLXSImporter/FileAccess/IXlsxSheetFilePromise.cs
+++ b/OpenXMLXLXSImporter/FileAccess/IXlsxSheetFilePromise.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OpenXMLXLSXImporter.FileAccess
+{
+    public interface IXlsxSheetFilePromise
+    {
+        Task<IXlsxSheetFile> GetLoadedFile();
+    }
+}

--- a/OpenXMLXLXSImporter/FileAccess/XlsxDocumentFile.cs
+++ b/OpenXMLXLXSImporter/FileAccess/XlsxDocumentFile.cs
@@ -45,7 +45,10 @@ namespace OpenXMLXLSXImporter.FileAccess
 
         Sheet IXlsxDocumentFile.GetSheet(string sheetName) => _sheetRef[sheetName];
 
+        CellFormat IXlsxDocumentFile.GetCellFormat(int index) => _cellFormats.ChildElements[index] as CellFormat;
+
         WorkbookPart IXlsxDocumentFile.WorkbookPart => _workbookPart;
+        OpenXmlElement IXlsxDocumentFile.GetSharedStringTableElement(int index) => _sharedStringTable.ElementAt(index);
 
         /// <summary>
         /// Common Reusable Parts of the WorkSheet
@@ -71,103 +74,7 @@ namespace OpenXMLXLSXImporter.FileAccess
         }
 
 
-        /// <summary>
-        /// This is for custom Cell Types like dates Cell with relations like text etc
-        /// </summary>
-        /// <param name="c"></param>
-        /// <param name="cellData"></param>
-        /// <returns></returns>
-        public bool ProcessCustomCell(Cell c, out ICellData cellData)
-        {
-            if (c.StyleIndex != null)
-            {
-                int index = int.Parse(c.StyleIndex.InnerText);
-                CellFormat cellFormat = _cellFormats.ChildElements[index] as CellFormat;
-                if (cellFormat != null)
-                {
-                    if (ExcelStaticData.DATE_FROMAT_DICTIONARY.ContainsKey(cellFormat.NumberFormatId))
-                    {
-                        if (!string.IsNullOrEmpty(c.CellValue.Text))
-                        {
-                            if (double.TryParse(c.CellValue.Text, out double cellDouble))
-                            {
-
-                                DateTime theDate = DateTime.FromOADate(cellDouble);
-                                cellData = new CellDataDate { Date = theDate, DateFormat = ExcelStaticData.DATE_FROMAT_DICTIONARY[cellFormat.NumberFormatId] };
-                                return true;
-                            }
-                        }
-                    }
-                }
-            }
-
-            if (c.DataType?.Value != null && c.DataType?.Value == CellValues.SharedString)
-            {
-                cellData = new CellDataRelation(int.Parse(c.CellValue.InnerText), _sharedStringTable);
-                return true;
-            }
-            cellData = null;
-            return false;
-        }
-
-        public static string GetColumnIndexByColumnReference(StringValue columnReference)
-        {
-            string v = columnReference.Value;
-            for (int i = v.Length - 1; i >= 0; i--)
-            {
-                char c = v[i];
-                if (!Char.IsNumber(c))
-                {
-                    return v.Substring(0, i + 1);
-                }
-
-            }
-            return v;
-        }
-
-        /// <summary>
-        /// this will be called for each work sheet and will process each cell
-        /// </summary>
-        /// <param name="worksheetPart"></param>
-        /// <param name="grid"></param>
-        /// <returns></returns>
-        //protected async Task ProcessWorkSheet(WorksheetPart worksheetPart, SpreadSheetGrid grid)
-        //{
-        //    await Task.Run(() => {
-        //        List<Task> cellTask = new List<Task>();
-        //        Worksheet ws = worksheetPart.Worksheet;
-        //        SheetData sheetData = ws.Elements<SheetData>().
-        //        IEnumerator<Row> enumerator = sheetData.Elements<Row>().GetEnumerator();
-        //        while (enumerator.MoveNext())
-        //        {
-        //            Row r = enumerator.Current;
-        //            IEnumerable<Cell> cells = r.Elements<Cell>();
-
-        //            foreach (Cell c in cells)
-        //            {
-        //                if (c?.CellValue != null)
-        //                {
-        //                    ICellData cellData;
-        //                    bool hasBeenProcessed = ProcessCustomCell(c, out cellData);
-        //                    if (!hasBeenProcessed)
-        //                    {
-        //                        cellData = new CellDataContent { Text = c.CellValue.Text };
-        //                    }
-
-        //                    if (cellData != null)
-        //                    {
-        //                        cellData.CellColumnIndex = GetColumnIndexByColumnReference(c.CellReference);
-        //                        cellData.CellRowIndex = r.RowIndex.Value;
-        //                        cellTask.Add(grid.Add(cellData));
-        //                    }
-        //                }
-        //            }
-        //        }
-        //        cellTask.ForEach(x => x.Wait());
-        //        grid.FinishedLoading();
-        //    });
-
-        //}
+       
 
         public async Task<IXlsxSheetFilePromise> LoadSpreadSheetData(ISheetProperties sheet)
         {
@@ -193,5 +100,6 @@ namespace OpenXMLXLSXImporter.FileAccess
             //}
             _spreadsheet.Dispose();
         }
+
     }
 }

--- a/OpenXMLXLXSImporter/FileAccess/XlsxDocumentFile.cs
+++ b/OpenXMLXLXSImporter/FileAccess/XlsxDocumentFile.cs
@@ -27,14 +27,14 @@ namespace OpenXMLXLSXImporter.FileAccess
         //The Task that Loads in the SpreadSheetDocumentData
         private Task _loadSpreadSheetData;
 
-        private Dictionary<string, SpreadSheetInstructionManager> _loadedSheets;
+        private Dictionary<string, IXlsxSheetFilePromise> _loadedSheets;
         private Dictionary<string, Sheet> _sheetRef;
 
         public XlsxDocumentFile(Stream stream)
         {
             _stream = stream;
             _loadSpreadSheetData = LoadSpreadSheetDocuemntData();
-            _loadedSheets = new Dictionary<string, SpreadSheetInstructionManager>();
+            _loadedSheets = new Dictionary<string, IXlsxSheetFilePromise>();
         }
 
         async Task<IXlsxDocumentFile> IXlsxDocumentFilePromise.GetLoadedFile()
@@ -169,7 +169,7 @@ namespace OpenXMLXLSXImporter.FileAccess
 
         //}
 
-        public async Task<SpreadSheetInstructionManager> LoadSpreadSheetData(ISheetProperties sheet)
+        public async Task<IXlsxSheetFilePromise> LoadSpreadSheetData(ISheetProperties sheet)
         {
             await _loadSpreadSheetData;
             if (_sheetRef.ContainsKey(sheet.Sheet))
@@ -177,7 +177,7 @@ namespace OpenXMLXLSXImporter.FileAccess
                 if (!_loadedSheets.ContainsKey(sheet.Sheet))
                 {
                     //this is the first time we use this sheet
-                    _loadedSheets[sheet.Sheet] = new SpreadSheetInstructionManager(this, sheet);
+                    _loadedSheets[sheet.Sheet] = new XlsxSheetFile(this, sheet.Sheet);
                 }
                 return _loadedSheets[sheet.Sheet];
             }

--- a/OpenXMLXLXSImporter/FileAccess/XlsxSheetFile.cs
+++ b/OpenXMLXLXSImporter/FileAccess/XlsxSheetFile.cs
@@ -10,17 +10,6 @@ using System.Threading.Tasks;
 
 namespace OpenXMLXLSXImporter.FileAccess
 {
-    public interface IXlsxSheetFile
-    {
-        bool TryGetRow(uint desiredRowIndex, out IEnumerator<Cell> cellEnumerator);
-        void ProcessedCell(Cell cellElement, ICellProcessingTask cellPromise);
-    }
-
-    public interface IXlsxSheetFilePromise
-    {
-        Task<IXlsxSheetFile> GetLoadedFile();
-    }
-
     public class XlsxSheetFile : IXlsxSheetFile, IXlsxSheetFilePromise
     {
         private IXlsxDocumentFilePromise _fileAccessPromise;

--- a/OpenXMLXLXSImporter/FileAccess/XlsxSheetFile.cs
+++ b/OpenXMLXLXSImporter/FileAccess/XlsxSheetFile.cs
@@ -1,0 +1,103 @@
+﻿using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OpenXMLXLSXImporter.FileAccess
+{
+    public interface IXlsxSheetFile
+    {
+        bool TryGetRow(uint desiredRowIndex, out IEnumerator<Cell> cellEnumerator);
+    }
+
+    public interface IXlsxSheetFilePromise
+    {
+        Task<IXlsxSheetFile> GetLoadedFile();
+    }
+
+    public class XlsxSheetFile : IXlsxSheetFile, IXlsxSheetFilePromise
+    {
+        private IXlsxDocumentFilePromise _fileAccessPromise;
+
+        private string _sheetName;
+
+        private Sheet _sheet;
+        private WorksheetPart _workbookPart;
+        private Worksheet _worksheet;
+        private SheetData _sheetData;
+
+        private Task _loadSpreadSheetData;
+
+        private IEnumerable<Row> _rowsEnumerable;
+        private IEnumerator<Row> _rowEnumerator;
+        private IEnumerable<Cell> _cellEnumerable;
+        private Row _row;
+        private bool _rowsLoadedIn ;
+
+        private UInt32Value _rowIndexNullable;
+        private uint _rowIndex;
+
+        private IDictionary<uint, IEnumerator<Cell>> _rows;
+
+        public XlsxSheetFile(IXlsxDocumentFilePromise fileAccess, string sheetName)
+        {
+            _fileAccessPromise = fileAccess;
+            _sheetName = sheetName;
+            _rowsLoadedIn = false;
+            _loadSpreadSheetData = Task.Run(LoadSpreadSheetData);
+        }
+
+        protected async Task LoadSpreadSheetData()
+        {
+            _rows = new Dictionary<uint, IEnumerator<Cell>>();
+            IXlsxDocumentFile fileAccess = await _fileAccessPromise.GetLoadedFile();
+            _sheet = fileAccess.GetSheet(_sheetName);
+            _workbookPart = fileAccess.WorkbookPart.GetPartById(_sheet.Id) as WorksheetPart;
+            _worksheet = _workbookPart.Worksheet;
+            _sheetData = _worksheet.Elements<SheetData>().First();
+           _rowsEnumerable = _sheetData.Elements<Row>();
+            _rowEnumerator = _rowsEnumerable.GetEnumerator();
+        }
+
+        public async Task<IXlsxSheetFile> GetLoadedFile()
+        {
+            await _loadSpreadSheetData;
+            return this;
+        }
+
+        bool IXlsxSheetFile.TryGetRow(uint desiredRowIndex, out IEnumerator<Cell> cellEnumerator)
+        {
+            //this will only load in up to the row we need
+            //if we try loading in a row that does not exist then we will load all of them in
+            //I'm assuming that data from here might still be in the file and we don't want to read things we don't need
+            while (!_rowsLoadedIn && !_rows.ContainsKey(desiredRowIndex))
+            {
+                if (_rowEnumerator.MoveNext())
+                {
+                    _row = _rowEnumerator.Current;
+                    _rowIndexNullable = _row.RowIndex;
+                    if (_rowIndexNullable.HasValue)
+                    {
+                        _rowIndex = _rowIndexNullable.Value;
+                        _cellEnumerable = _row.Elements<Cell>();
+                        cellEnumerator = _cellEnumerable.GetEnumerator();
+                        _rows.Add(_rowIndex, cellEnumerator);
+                        if (_rowIndex == desiredRowIndex)
+                            return true;
+                    }
+                }
+                else
+                {
+                    _rowsLoadedIn = true;
+                    break;
+                }
+            }
+            cellEnumerator = null;
+            return false;
+        }
+    }
+}

--- a/OpenXMLXLXSImporter/FileAccess/XlsxSheetFile.cs
+++ b/OpenXMLXLXSImporter/FileAccess/XlsxSheetFile.cs
@@ -13,7 +13,7 @@ namespace OpenXMLXLSXImporter.FileAccess
     public interface IXlsxSheetFile
     {
         bool TryGetRow(uint desiredRowIndex, out IEnumerator<Cell> cellEnumerator);
-        void GetProcessedCell(Cell cellElement, ICellProcessingTask cellPromise);
+        void ProcessedCell(Cell cellElement, ICellProcessingTask cellPromise);
     }
 
     public interface IXlsxSheetFilePromise
@@ -103,7 +103,7 @@ namespace OpenXMLXLSXImporter.FileAccess
             return false;
         }
 
-        void IXlsxSheetFile.GetProcessedCell(Cell cellElement, ICellProcessingTask cellPromise)
+        void IXlsxSheetFile.ProcessedCell(Cell cellElement, ICellProcessingTask cellPromise)
         {
             ICellData cellData;
             bool hasBeenProcessed = ProcessCustomCell(cellElement, out cellData);
@@ -156,7 +156,8 @@ namespace OpenXMLXLSXImporter.FileAccess
             if (c.DataType?.Value != null && c.DataType?.Value == CellValues.SharedString)
             {
                 int index = int.Parse(c.CellValue.InnerText);
-                cellData = new CellDataRelation(index, _fileAccess.GetSharedStringTableElement(index));
+                OpenXmlElement sharedStringElement = _fileAccess.GetSharedStringTableElement(index);
+                cellData = new CellDataRelation(index, sharedStringElement);
                 return true;
             }
             cellData = null;

--- a/OpenXMLXLXSImporter/Processing/SpreadSheetDequeManager.cs
+++ b/OpenXMLXLXSImporter/Processing/SpreadSheetDequeManager.cs
@@ -27,6 +27,8 @@ namespace OpenXMLXLSXImporter.Processing
             _processRequestTask = null;
         }
 
+        public void Finish() => _queue.Finish();
+
         public void Init(ChunkableBlockingCollection<ICellProcessingTask> collection)
         {
             _queue = collection;

--- a/OpenXMLXLXSImporter/Processing/SpreadSheetDequeManager.cs
+++ b/OpenXMLXLXSImporter/Processing/SpreadSheetDequeManager.cs
@@ -46,7 +46,7 @@ namespace OpenXMLXLSXImporter.Processing
         {
             try
             {
-                Cell cell;
+                Cell cell = null;
                 uint desiredRowIndex;
                 bool rowsLoadedIn = false;
                 IEnumerator<Cell> cellEnumerator;
@@ -81,7 +81,7 @@ namespace OpenXMLXLSXImporter.Processing
 
                         if (currentIndex == columnIndex)
                         {
-                            throw new NotImplementedException();//need to handle this step now which is loading in the actual data
+                            sheetAccess.ProcessedCell(cell, t);
                         }
                         else
                         {

--- a/OpenXMLXLXSImporter/Processing/SpreadSheetDequeManager.cs
+++ b/OpenXMLXLXSImporter/Processing/SpreadSheetDequeManager.cs
@@ -1,5 +1,7 @@
-﻿using Nito.AsyncEx;
+﻿using DocumentFormat.OpenXml.Spreadsheet;
+using Nito.AsyncEx;
 using OpenXMLXLSXImporter.CellData;
+using OpenXMLXLSXImporter.FileAccess;
 using OpenXMLXLSXImporter.Utils;
 using System;
 using System.Collections.Concurrent;
@@ -13,10 +15,92 @@ namespace OpenXMLXLSXImporter.Processing
 {
     public class SpreadSheetDequeManager : IChunckBlock<ICellProcessingTask>
     {
+        private ChunkableBlockingCollection<ICellProcessingTask> _queue;
+
         private Queue<DeferredCell> deferedCells = null;
+        private IXlsxSheetFilePromise _filePromise;
+
+        private Task _processRequestTask;
         public SpreadSheetDequeManager()
         {
-            
+            _filePromise = null;
+            _processRequestTask = null;
+        }
+
+        public void Init(ChunkableBlockingCollection<ICellProcessingTask> collection)
+        {
+            _queue = collection;
+        }
+
+        public void StartRequestProcessor(IXlsxSheetFilePromise file)
+        {
+            if (_processRequestTask == null)
+            {
+                _filePromise = file;
+                _processRequestTask = Task.Run(ProcessRequests);
+            }
+
+        }
+
+        protected async Task ProcessRequests()
+        {
+            try
+            {
+                Cell cell;
+                uint desiredRowIndex;
+                bool rowsLoadedIn = false;
+                IEnumerator<Cell> cellEnumerator;
+                IXlsxSheetFile sheetAccess = await _filePromise.GetLoadedFile();
+
+                while (true)
+                {
+                    ICellProcessingTask t = _queue.Take();
+                    desiredRowIndex = t.CellRowIndex;
+                    if (sheetAccess.TryGetRow(desiredRowIndex, out cellEnumerator))
+                    {
+                        string columnIndex = t.CellColumnIndex;
+                        bool cellsLoadedIn = false;
+                        string currentIndex;
+                        do
+                        {
+                            if (cellEnumerator.MoveNext())
+                            {
+                                cell = cellEnumerator.Current;
+                                currentIndex = XlsxDocumentFile.GetColumnIndexByColumnReference(cell.CellReference);
+                                if (currentIndex != columnIndex)
+                                {
+                                    this.AddDeferredCell(new DeferredCell(desiredRowIndex, currentIndex, cell));
+                                }
+                            }
+                            else
+                            {
+                                currentIndex = null;
+                                cellsLoadedIn = true;
+                            }
+                        } while (!cellsLoadedIn && currentIndex != columnIndex);
+
+                        if (currentIndex == columnIndex)
+                        {
+                            throw new NotImplementedException();//need to handle this step now which is loading in the actual data
+                        }
+                        else
+                        {
+                            //This Cell Does not exist
+                            t.Resolve(null);
+                        }
+
+                    }
+                    else
+                    {
+                        //if we reached the end of the file and the row does not exist then what were trying to get does not exist
+                        t.Resolve(null);
+                    }
+                }
+            }
+            catch (InvalidOperationException ex)
+            {
+                //queue is finished
+            }
         }
 
         public void AddDeferredCell(DeferredCell deferredCell)

--- a/OpenXMLXLXSImporter/Processing/SpreadSheetDequeManager.cs
+++ b/OpenXMLXLXSImporter/Processing/SpreadSheetDequeManager.cs
@@ -66,7 +66,7 @@ namespace OpenXMLXLSXImporter.Processing
                             if (cellEnumerator.MoveNext())
                             {
                                 cell = cellEnumerator.Current;
-                                currentIndex = XlsxDocumentFile.GetColumnIndexByColumnReference(cell.CellReference);
+                                currentIndex = XlsxSheetFile.GetColumnIndexByColumnReference(cell.CellReference);
                                 if (currentIndex != columnIndex)
                                 {
                                     this.AddDeferredCell(new DeferredCell(desiredRowIndex, currentIndex, cell));

--- a/OpenXMLXLXSImporter/Processing/SpreadSheetInstructionManager.cs
+++ b/OpenXMLXLXSImporter/Processing/SpreadSheetInstructionManager.cs
@@ -24,25 +24,14 @@ namespace OpenXMLXLSXImporter.Processing
     /// interate through all the cells for an entire row
     /// interate through all the cells
     /// </summary>
-    public class SpreadSheetInstructionManager : ISpreadSheetIndexersLock, IDisposable
-    {
-        private IXlsxDocumentFilePromise _fileAccessPromise;
-        private ISheetProperties _sheetProperties;
-
-        private Sheet _sheet;
-        private WorksheetPart _workbookPart;
-        private Worksheet _worksheet;
-        private SheetData _sheetData;
-
-        private Task _loadSpreadSheetData;
-
+    public class SpreadSheetInstructionManager : ISpreadSheetIndexersLock
+    {       
         private RowIndexer _rows;
         private ColumnIndexer _columns;
         private AsyncLock _accessorLock = new AsyncLock();
         private List<IIndexer> _indexers;
 
         private ChunkableBlockingCollection<ICellProcessingTask> _loadQueueManager;
-        private SpreadSheetDequeManager _dequeuer;
 
         AsyncLock ISpreadSheetIndexersLock.IndexerLock => _accessorLock;
 
@@ -65,131 +54,13 @@ namespace OpenXMLXLSXImporter.Processing
             _loadQueueManager.Enque(cell);
         }
 
-        public SpreadSheetInstructionManager(IXlsxDocumentFilePromise fileAccess, ISheetProperties sheetProperties)
+        public SpreadSheetInstructionManager(SpreadSheetDequeManager dequeManager)
         {
-            _fileAccessPromise = fileAccess;
-            _sheetProperties = sheetProperties;
             _indexers = new List<IIndexer>();
-            _dequeuer = new SpreadSheetDequeManager();
-            _loadQueueManager = new ChunkableBlockingCollection<ICellProcessingTask>(_dequeuer);
-
-            _loadSpreadSheetData = Task.Run(LoadSpreadSheetData);
+            _loadQueueManager = new ChunkableBlockingCollection<ICellProcessingTask>(dequeManager);
 
             _rows = new RowIndexer(this);
             _columns = new ColumnIndexer(this);
-        }
-
-        protected async Task LoadSpreadSheetData()
-        {
-            IXlsxDocumentFile fileAccess = await _fileAccessPromise.GetLoadedFile();
-            _sheet = fileAccess.GetSheet(_sheetProperties.Sheet);
-            _workbookPart = fileAccess.WorkbookPart.GetPartById(_sheet.Id) as WorksheetPart;
-            _worksheet = _workbookPart.Worksheet;
-            _sheetData = _worksheet.Elements<SheetData>().First();
-            try
-            {
-                IEnumerable<Row> rowsEnumerable = _sheetData.Elements<Row>();
-                IEnumerator<Row> rowEnumerator = rowsEnumerable.GetEnumerator();
-                IDictionary<uint,IEnumerator<Cell>> rows;//store the raw rows
-               // if (rowsEnumerable.TryGetNonEnumeratedCount(out int count))//does look like in my testing the count is not determind
-                rows = new Dictionary<uint, IEnumerator<Cell>>();//lets user a dictionary in this case
-                Row row;
-                Cell cell;
-                UInt32Value rowIndexNullable;
-                uint rowIndex;
-                uint desiredRowIndex;
-                bool rowsLoadedIn = false;
-
-                IEnumerable<Cell> cellEnumerable;
-                IEnumerator<Cell> cellEnumerator;
-                
-
-                while (true)
-                {
-                    ICellProcessingTask t = _loadQueueManager.Take();
-                    desiredRowIndex = t.CellRowIndex;
-
-                    //this will only load in up to the row we need
-                    //if we try loading in a row that does not exist then we will load all of them in
-                    //I'm assuming that data from here might still be in the file and we don't want to read things we don't need
-                    while (!rowsLoadedIn && !rows.ContainsKey(desiredRowIndex))
-                    {
-                        if(rowEnumerator.MoveNext())
-                        {
-                            row = rowEnumerator.Current;
-                            rowIndexNullable = row.RowIndex;
-                            if (rowIndexNullable.HasValue)
-                            {
-                                rowIndex = rowIndexNullable.Value;
-                                cellEnumerable = row.Elements<Cell>();
-                                cellEnumerator = cellEnumerable.GetEnumerator();
-                                rows.Add(rowIndex, cellEnumerator);
-                                if (rowIndex == desiredRowIndex)
-                                    break;
-                            }
-                        }
-                        else
-                        {
-                            rowsLoadedIn = true;
-                            break;
-                        }
-                    }
-
-                    
-                    if(rows.ContainsKey(desiredRowIndex))
-                    {
-                        string columnIndex = t.CellColumnIndex;
-                        cellEnumerator = rows[desiredRowIndex];
-                        bool cellsLoadedIn = false;
-                        string currentIndex;
-                        do
-                        {
-                            if(cellEnumerator.MoveNext())
-                            {
-                                cell = cellEnumerator.Current;
-                                currentIndex = XlsxDocumentFile.GetColumnIndexByColumnReference(cell.CellReference);
-                                if(currentIndex != columnIndex)
-                                {
-                                    _dequeuer.AddDeferredCell(new DeferredCell(desiredRowIndex, currentIndex, cell));
-                                }
-                            }
-                            else
-                            {
-                                currentIndex = null;
-                                cellsLoadedIn = true;
-                            }
-                        } while (!cellsLoadedIn&&currentIndex != columnIndex);
-
-                        if(currentIndex == columnIndex)
-                        {
-                            throw new NotImplementedException();//need to handle this step now which is loading in the actual data
-                        }
-                        else
-                        {
-                            //This Cell Does not exist
-                            t.Resolve(null);
-                        }
-
-                    }
-                    else
-                    {
-                        //if we reached the end of the file and the row does not exist then what were trying to get does not exist
-                        t.Resolve(null);
-                    }
-
-
-                }
-            }
-            catch (InvalidOperationException ex)
-            {
-                //queue is finished
-            }
-
-        }
-
-        public void Dispose()
-        {
-            _loadSpreadSheetData.Wait();
         }
 
         public async Task ProcessInstruction(ISpreadSheetInstruction spreadSheetInstruction)

--- a/OpenXMLXLXSImporter/Utils/ChunkableBlockingCollection.cs
+++ b/OpenXMLXLXSImporter/Utils/ChunkableBlockingCollection.cs
@@ -10,6 +10,8 @@ namespace OpenXMLXLSXImporter.Utils
 {
     public interface IChunckBlock<T>
     {
+        void Init(ChunkableBlockingCollection<T> collection);
+
         bool ShouldPullAndChunk { get; }
 
         bool KeepQueueLockedForDump();
@@ -30,6 +32,7 @@ namespace OpenXMLXLSXImporter.Utils
             _mre = new ManualResetEventSlim(true);//we will make the mre's inital state as true
             _queue = new BlockingCollection<T>();
             _chunkedItems = null;
+            chunkBlock.Init(this);
         }
 
         public void Enque(T item)

--- a/OpenXMLXLXSImporter/Utils/ChunkableBlockingCollection.cs
+++ b/OpenXMLXLXSImporter/Utils/ChunkableBlockingCollection.cs
@@ -61,6 +61,8 @@ namespace OpenXMLXLSXImporter.Utils
             _chunkedItems = queueOutput.GetEnumerator();
         }
 
+        public void Finish() => _queue.CompleteAdding();
+
         public T Take()
         {
             if (_chunkedItems != null)


### PR DESCRIPTION
- Added a new class called ```XlsxSheetFile``` 
  - this class will handle Sheet Specific file access
  - Moved the ProcessCell stuff from ```XlsxDocumentFile``` to ```XlsxSheetFile``` as the data processed in there is sheet specific.
- Moved stuff the deque stuff into the ```SpreadSheetDequeManager``` which will no also be incharge of dequing the items and call the ProcessCell method in another thread
- Added ```IXlsxSheetFilePromise``` for sheet specific requirements
  - don't lock things up
- Added Finish method to ```ChunkableBlockingCollection``` to notify that we no longer taking requests
  - This will end the ```SpreadSheetDequeManager``` ```ProcessRequest``` thread