### PR TITLE
Fixed issue where Column letter positions indexes where stored backwards

### DIFF
--- a/OpenXMLXLXSImporter/Utils/ExcelColumnHelper.cs
+++ b/OpenXMLXLXSImporter/Utils/ExcelColumnHelper.cs
@@ -12,12 +12,13 @@ namespace OpenXMLXLSXImporter.Utils
         public static uint GetColumnStringAsIndex(string s)
         {
             char[] chars = s.ToArray();
+            uint log = (uint)(chars.Length - 1);
             uint[] charValuesAtZero = new uint[chars.Length];
             for (uint i = 0; i < chars.Length; i++)
             {
                 if (chars[i] < 128 && Char.IsLetter(chars[i]))
                 {
-                    charValuesAtZero[i] = (uint)(Char.ToUpperInvariant(chars[i]) - 65);
+                    charValuesAtZero[log - i] = (uint)(Char.ToUpperInvariant(chars[i]) - 65);
                 }
                 else
                 {
@@ -32,7 +33,6 @@ namespace OpenXMLXLSXImporter.Utils
                 sum += (uint)(charValuesAtZero[i] * Math.Floor(Math.Pow(BASE, i)));
             }
 
-            uint log = (uint)(charValuesAtZero.Length - 1);
             sum = sum + Normalize(log);
 
             return sum;
@@ -56,13 +56,16 @@ namespace OpenXMLXLSXImporter.Utils
 
             uint normalizedIndex = index - Normalize(log);
 
-            for (uint count = 0; normalizedIndex + digits > 0; digits--)
+            uint count = log;
+
+            while (normalizedIndex + digits > 0)
             {
                 uint digit = normalizedIndex % BASE;
                 char c = (char)(digit + 65);
-                results[count++] = c;
-                
+                results[count--] = c;
+
                 normalizedIndex = normalizedIndex / BASE;
+                digits--;
             }
             return new string(results);
             }

--- a/SSUT/EncodingTest.cs
+++ b/SSUT/EncodingTest.cs
@@ -18,6 +18,22 @@ namespace SSUT
                 indexs[i] = ExcelColumnHelper.GetColumnStringAsIndex(testColumns[i]);
             }
 
+
+            //Sequential test
+            if(indexs.Length > 0)
+            {
+                uint sequenceTest = indexs[0];
+                for (int i = 1; i < indexs.Length; i++)
+                {
+                    sequenceTest++;
+                    Assert.AreEqual(sequenceTest, indexs[i]);
+                }
+            }
+
+
+
+
+
             //Reconvert it back
             string[] unencoded = new string[indexs.Length];
 


### PR DESCRIPTION
- accidently count the columns
   - Example for indexes 25, 26, 27 which are Z, AA, AB accidently where Z, AA, BA